### PR TITLE
Add docker-compose.yaml for deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  gemini-to-openai-proxy:
+    image: ghcr.io/cheahjs/gemini-to-openai-proxy:latest
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - LISTEN_ADDR=${LISTEN_ADDR}
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
Related to #2

Add a `docker-compose.yaml` file for deploying the proxy.

* Define a service named `gemini-to-openai-proxy` that pulls a Docker image from GHCR.
* Set the `GEMINI_API_KEY` and `LISTEN_ADDR` environment variables for the `gemini-to-openai-proxy` service.
* Expose port 8080 for the `gemini-to-openai-proxy` service.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cheahjs/gemini-to-openai-proxy/issues/2?shareId=b50f85ac-1a16-4e88-b9b7-b42eaae530a3).